### PR TITLE
Bugfix terminate ryuk containers in tests

### DIFF
--- a/common/src/test/scala/repository/ContractsRepositoryPostgresImplSpec.scala
+++ b/common/src/test/scala/repository/ContractsRepositoryPostgresImplSpec.scala
@@ -1,48 +1,59 @@
 package io.github.sergeiionin.contractsregistrator
 package repository
 
-import cats.syntax.option.*
-import cats.effect.IO
-import cats.effect.Resource
-import cats.effect.unsafe.implicits.global
-import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
-import cats.effect.testing.specs2.CatsEffect
-import org.specs2.mutable.Specification
-import org.specs2.matcher.ShouldMatchers
-import org.specs2.mutable.*
-import skunk.Session
-import skunk.codec.all.*
-import skunk.*
-import skunk.implicits.*
-import natchez.Trace.Implicits.noop
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.typelevel.log4cats.{Logger, LoggerFactory}
 import domain.Contract
-
 import domain.SchemaType.PROTOBUF
 
-class ContractsRepositoryPostgresImplSpec extends Specification with CatsEffect with PostgresHelper[IO]:
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Resource}
+import cats.syntax.option.*
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import com.dimafeng.testcontainers.{Container, ForAllTestContainer, ForEachTestContainer, PostgreSQLContainer}
+import natchez.Trace.Implicits.noop
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.utility.DockerImageName
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.{Logger, LoggerFactory}
+import skunk.*
+import skunk.codec.all.*
+import skunk.implicits.*
+
+class ContractsRepositoryPostgresImplSpec extends AnyWordSpec with Matchers with TestContainerForAll with PostgresHelper[IO]:
   import ContractsRepositoryPostgresImplSpec.given
-  
+
   val logger: Logger[IO] = summon[Logger[IO]]
 
   val testSubject: String = "testSubject"
   val testId1: Int = 3
-  val testId2: Int = testId1+1
+  val testId2: Int = testId1 + 1
   val testVersion1: Int = 1
-  val testVersion2: Int = testVersion1+1
+  val testVersion2: Int = testVersion1 + 1
   val testSchema1: String = "testSchema_1"
   val testSchema2: String = "testSchema_2"
   val testContractV1: Contract = Contract(testSubject, testVersion1, testId1, testSchema1, PROTOBUF)
   val testContractV2: Contract = Contract(testSubject, testVersion2, testId2, testSchema2, PROTOBUF)
-  
+
+  override val containerDef = PostgreSQLContainer.Def(
+    dockerImageName = DockerImageName.parse("postgres:16.3"),
+    databaseName = "testcontainer-scala",
+    username = "scala",
+    password = "scala"
+  )
+
+  override def beforeContainersStop(containers: Containers): Unit =
+    super.beforeContainersStop(containers)
+    println("Shutting down ryuk container...")
+    after_All()
+
   "ContractsRepositoryPostgresImpl" should {
     "perform CRUD operations correctly" in {
-      (for
-        postgres <- postgresResource
-        sessionR <- sessionPooledResource(postgres)
-        repo <- ContractsRepository.make[IO](sessionR)
-      yield (sessionR, repo)).use { (sR, repository) => {
+      withContainers { container =>
+        val psqlContainer: PostgreSQLContainer = container.asInstanceOf[PostgreSQLContainer]
+        (for
+          sessionR <- sessionPooledResource(psqlContainer)
+          repo <- ContractsRepository.make[IO](sessionR)
+        yield (sessionR, repo)).use { (sR, repository) => {
           for
             _ <- initPostgres(sR)
             _ <- repository.save(testContractV1)
@@ -50,33 +61,34 @@ class ContractsRepositoryPostgresImplSpec extends Specification with CatsEffect 
             resOpt1 <- repository.get(testSubject, 1)
             _ <- IO.whenA(resOpt1.isEmpty)(IO.raiseError(new RuntimeException("Contract not found")))
             res1 = resOpt1.get
-            _ = res1 must beEqualTo(testContractV1)
+            _ = res1 shouldBe testContractV1
             versionsS <- repository.getAllVersionsForSubject(testSubject)
             versions <- versionsS.compile.toList
-            _ = versions must beEqualTo(List(1, 2))
+            _ = versions shouldBe List(1, 2)
             _ <- repository.delete(testSubject, 2)
             resOpt2 <- repository.get(testSubject, 2)
-            _ = resOpt2 must beNone
+            _ = resOpt2 shouldBe None
             _ <- repository.save(testContractV2)
             _ <- repository.updateIsMerged(testContractV2.subject, testContractV2.version)
             resOpt2 <- repository.get(testSubject, 2)
-            _ = resOpt2.exists(_.isMerged) must beTrue
+            _ = resOpt2.exists(_.isMerged) shouldBe true
             versionsS <- repository.getAllVersionsForSubject(testSubject)
             versions <- versionsS.compile.toList
-            _ = versions must beEqualTo(List(1, 2))
+            _ = versions shouldBe List(1, 2)
             _ <- versionsS.parEvalMapUnordered(10)(version =>
-                    repository.delete(testSubject, version)
-                 ).compile.drain
+              repository.delete(testSubject, version)
+            ).compile.drain
             resOpt1 <- repository.get(testSubject, 1)
             resOpt2 <- repository.get(testSubject, 2)
-            _ = resOpt1 must beNone
-            _ = resOpt2 must beNone
+            _ = resOpt1 shouldBe None
+            _ = resOpt2 shouldBe None
           yield true
         }
+        }.unsafeRunSync()
       }
     }
   }
-  
+
 object ContractsRepositoryPostgresImplSpec:
   given logger: Logger[IO] = Slf4jLogger.getLogger[IO]
     

--- a/common/src/test/scala/repository/PostgresHelper.scala
+++ b/common/src/test/scala/repository/PostgresHelper.scala
@@ -1,35 +1,44 @@
 package io.github.sergeiionin.contractsregistrator
 package repository
 
+import scala.util.{Try, Success, Failure}
 import cats.syntax.option.*
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.unsafe.implicits.global
-import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
+import com.dimafeng.testcontainers.{Container, ForAllTestContainer, PostgreSQLContainer}
 import cats.effect.testing.specs2.CatsEffect
 import org.specs2.mutable.Specification
 import org.specs2.matcher.ShouldMatchers
 import org.specs2.mutable.*
 import skunk.Session
-import skunk.codec.all._
+import skunk.codec.all.*
 import skunk.*
 import skunk.implicits.*
 import natchez.Trace.Implicits.noop
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, LoggerFactory}
 import domain.Contract
+import com.github.dockerjava.api.DockerClient
+import com.github.dockerjava.core.{DefaultDockerClientConfig, DockerClientBuilder}
+
+import org.scalatest.BeforeAndAfterAll
 
 trait PostgresHelper[F[_]]:
-  lazy val container: PostgreSQLContainer = PostgreSQLContainer()
 
-  lazy val postgresResource: Resource[IO, PostgreSQLContainer] =
-    Resource.make(IO.delay {
-      container.start()
-      container
-    })(c => {
-      IO.delay(c.stop())
-    })
-
+  // todo this is a hack for the case when sidecar ryuk-containers weren't terminated after test. Any chance to make it better?
+  def after_All(): Unit =
+    val dockerClient: DockerClient = DockerClientBuilder.getInstance(DefaultDockerClientConfig.createDefaultConfigBuilder().build()).build()
+    dockerClient.listContainersCmd().exec().forEach { container =>
+      if (container.getImage.contains("testcontainers")) {
+        val id = container.getId
+        println(s"removing container: ${container.getNames.toList.mkString(", ")}, id: ${container.getId}")
+        Try(dockerClient.stopContainerCmd(id).exec()) match 
+          case Failure(e) => println(s"error stopping ryuk container: ${e.getMessage}")
+          case Success(_) => ()
+      }
+    }
+  
   def initPostgres(session: Session[IO]): IO[Unit] =
     session.execute(
       sql"""CREATE TABLE contracts(
@@ -63,12 +72,13 @@ trait PostgresHelper[F[_]]:
       database = container.databaseName
     )
 
-  def sessionPooledResource(container: PostgreSQLContainer): Resource[IO, Resource[IO, Session[IO]]] =
+  def sessionPooledResource(container: Container): Resource[IO, Resource[IO, Session[IO]]] =
+    val postgresContainer = container.asInstanceOf[PostgreSQLContainer]
     Session.pooled[IO](
-      host = container.containerIpAddress,
-      port = container.firstMappedPort,
-      user = container.username,
-      password = container.password.some,
-      database = container.databaseName,
+      host = postgresContainer.containerIpAddress,
+      port = postgresContainer.firstMappedPort,
+      user = postgresContainer.username,
+      password = postgresContainer.password.some,
+      database = postgresContainer.databaseName,
       max = 10
     ) 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
     val testcontainers = "0.41.4"
     val scalatest = "3.2.19"
     val `specs2-cats` = "4.20.8"
+    val `docker-java` = "3.4.0"
   }
 
   lazy val catsDependencies =
@@ -81,9 +82,10 @@ object Dependencies {
 
   lazy val testDependencies =
     Seq(
-      "org.scalatest" %% "scalatest"                     % Versions.scalatest % Test,
-      "org.specs2"    %% "specs2-cats"                   % Versions.`specs2-cats` % Test,
-      "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % Versions.tapir % Test
+      "org.scalatest"               %% "scalatest"                     % Versions.scalatest % Test,
+      "org.specs2"                  %% "specs2-cats"                   % Versions.`specs2-cats` % Test,
+      "com.github.docker-java"      % "docker-java"                    % Versions.`docker-java` % Test,
+      "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server"        % Versions.tapir % Test
     ) ++
     Seq("testcontainers-scala-core", "testcontainers-scala-kafka",
       "testcontainers-scala-scalatest", "testcontainers-scala-postgresql")

--- a/reader/src/test/scala/handler/ContractsHandlerSpec.scala
+++ b/reader/src/test/scala/handler/ContractsHandlerSpec.scala
@@ -1,27 +1,29 @@
 package io.github.sergeiionin.contractsregistrator
 package handler
 
-import cats.effect.IO
-import cats.effect.Resource
+import repository.PostgresHelper
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import org.scalatest.wordspec.AnyWordSpec
+import domain.Contract
+import domain.SchemaType.PROTOBUF
+import github.{GitHubClient, GitHubClientTestImpl}
+import repository.{ContractsRepository, PostgresHelper}
+import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global
-import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
-import cats.effect.testing.specs2.CatsEffect
-import org.specs2.mutable.Specification
-import org.specs2.matcher.ShouldMatchers
-import org.specs2.mutable.*
-import skunk.Session
-import skunk.codec.all.*
-import skunk.*
-import skunk.implicits.*
+import com.dimafeng.testcontainers.{Container, ForAllTestContainer, PostgreSQLContainer}
 import natchez.Trace.Implicits.noop
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.utility.DockerImageName
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, LoggerFactory}
-import domain.Contract
-import repository.{ContractsRepository, PostgresHelper}
-import github.{GitHubClient, GitHubClientTestImpl}
-import domain.SchemaType.PROTOBUF
+import skunk.*
+import skunk.codec.all.*
+import skunk.implicits.*
 
-class ContractsHandlerSpec extends Specification with CatsEffect with PostgresHelper[IO]:
+// fixme when this test is run through sbt, a container don't shutdown
+class ContractsHandlerSpec extends AnyWordSpec with Matchers with TestContainerForAll with PostgresHelper[IO]:
   import ContractsHandlerSpec.given
 
   val logger: Logger[IO] = summon[Logger[IO]]
@@ -35,34 +37,49 @@ class ContractsHandlerSpec extends Specification with CatsEffect with PostgresHe
   val testSchema2: String = "testSchema_2"
   val testContractV1: Contract = Contract(testSubject, testVersion1, testId1, testSchema1, PROTOBUF)
   val testContractV2: Contract = Contract(testSubject, testVersion2, testId2, testSchema2, PROTOBUF)
-  
+
+  override val containerDef = PostgreSQLContainer.Def(
+    dockerImageName = DockerImageName.parse("postgres:16.3"),
+    databaseName = "testcontainer-scala",
+    username = "scala",
+    password = "scala"
+  )
+
+  override def beforeContainersStop(containers: Containers): Unit = {
+    super.beforeContainersStop(containers)
+    println("Shutting down ryuk container...")
+    after_All()
+  }
+
   "ContractsHandler" should {
     "add, set isMerged status and delete contracts" in {
-      (for
-        postgres  <- postgresResource
-        session   <- sessionPooledResource(postgres)
-        _         <- Resource.eval(initPostgres(session))
-        repo      <- ContractsRepository.make[IO](session)
-        gitClient <- GitHubClient.test[IO]()
-        handler   <- ContractsHandler.make[IO](repo, gitClient)
-      yield (handler, repo)).use { (h: ContractsHandler[IO], r: ContractsRepository[IO]) => {
+      withContainers { container =>
+        val psqlContainer: PostgreSQLContainer = container.asInstanceOf[PostgreSQLContainer]
+        (for
+          session <- sessionPooledResource(psqlContainer)
+          _ <- Resource.eval(initPostgres(session))
+          repo <- ContractsRepository.make[IO](session)
+          gitClient <- GitHubClient.test[IO]()
+          handler <- ContractsHandler.make[IO](repo, gitClient)
+        yield (handler, repo)).use { (h: ContractsHandler[IO], r: ContractsRepository[IO]) => {
           for
             _ <- h.addContract(testContractV1)
             _ <- h.addContract(testContractV2)
             versionsS <- r.getAllVersionsForSubject(testSubject)
             versions <- versionsS.compile.toList
             _ <- logger.info(s"versions before deleting: $versions")
-            _ = versions must beEqualTo(List(1, 2))
+            _ = versions shouldBe List(1, 2)
             _ <- h.updateIsMergedStatus(testSubject, testVersion2)
             contractOpt <- r.get(testSubject, testVersion2)
             _ <- logger.info(s"contract after setting isMerged: $contractOpt")
-            _ = contractOpt.exists(_.isMerged) must beTrue
+            _ = contractOpt.exists(_.isMerged) shouldBe true
             _ <- h.deleteContract(testSubject)
             versionsS <- r.getAllVersionsForSubject(testSubject)
             versions <- versionsS.compile.toList
-            _ = versions must beEmpty
+            _ = versions shouldBe Nil
           yield true
         }
+        }.unsafeRunSync()
       }
     }
   }


### PR DESCRIPTION
Adding `docker-java` client to explicitly stop `ryuk` sidecar testcontainers which weren't properly terminated upon running `sbt test` or `sbt testOnly <testName>`